### PR TITLE
FIFO queue support

### DIFF
--- a/eb_sqs/aws/sqs_queue_client.py
+++ b/eb_sqs/aws/sqs_queue_client.py
@@ -4,6 +4,8 @@ import boto3
 from botocore.config import Config
 from botocore.exceptions import ClientError
 
+import uuid
+
 from eb_sqs import settings
 from eb_sqs.worker.queue_client import QueueClient, QueueDoesNotExistException, QueueClientException
 
@@ -64,9 +66,10 @@ class SqsQueueClient(QueueClient):
             queue = self._get_queue(queue_name)
             is_fifo = queue_name.endswith('.fifo')
             if is_fifo:
+                message_group_id = fifo_group if fifo_group else uuid.uuid4().hex
                 queue.send_message(
                     MessageBody=msg,
-                    MessageGroupId=fifo_group
+                    MessageGroupId=message_group_id
                 )
             else:
                 queue.send_message(

--- a/eb_sqs/aws/sqs_queue_client.py
+++ b/eb_sqs/aws/sqs_queue_client.py
@@ -58,13 +58,20 @@ class SqsQueueClient(QueueClient):
         else:
             raise QueueDoesNotExistException(queue_name)
 
-    def add_message(self, queue_name, msg, delay):
+    def add_message(self, queue_name, group_id, msg, delay):
         # type: (unicode, unicode, int) -> None
         try:
             queue = self._get_queue(queue_name)
-            queue.send_message(
-                MessageBody=msg,
-                DelaySeconds=delay
-            )
+            is_fifo = queue_name.endswith('.fifo')
+            if is_fifo:
+                queue.send_message(
+                    MessageBody=msg,
+                    MessageGroupId=group_id
+                )
+            else:
+                queue.send_message(
+                    MessageBody=msg,
+                    DelaySeconds=delay
+                )
         except Exception as ex:
             raise QueueClientException(ex)

--- a/eb_sqs/aws/sqs_queue_client.py
+++ b/eb_sqs/aws/sqs_queue_client.py
@@ -58,7 +58,7 @@ class SqsQueueClient(QueueClient):
         else:
             raise QueueDoesNotExistException(queue_name)
 
-    def add_message(self, queue_name, group_id, msg, delay):
+    def add_message(self, queue_name, fifo_group, msg, delay):
         # type: (unicode, unicode, int) -> None
         try:
             queue = self._get_queue(queue_name)
@@ -66,7 +66,7 @@ class SqsQueueClient(QueueClient):
             if is_fifo:
                 queue.send_message(
                     MessageBody=msg,
-                    MessageGroupId=group_id
+                    MessageGroupId=fifo_group
                 )
             else:
                 queue.send_message(

--- a/eb_sqs/decorators.py
+++ b/eb_sqs/decorators.py
@@ -10,7 +10,7 @@ def _get_kwarg_val(kwargs, key, default):
     return kwargs.pop(key, default) if kwargs else default
 
 
-def func_delay_decorator(func, queue_name, max_retries_count, use_pickle):
+def func_delay_decorator(func, queue_name, group_id, max_retries_count, use_pickle):
     # type: (Any, str, int, bool) -> (tuple, dict)
     def wrapper(*args, **kwargs):
         # type: (tuple, dict) -> Any
@@ -20,7 +20,6 @@ def func_delay_decorator(func, queue_name, max_retries_count, use_pickle):
 
         execute_inline = _get_kwarg_val(kwargs, 'execute_inline', False) or settings.EXECUTE_INLINE
         delay = _get_kwarg_val(kwargs, 'delay',  settings.DEFAULT_DELAY)
-        group_id = _get_kwarg_val(kwargs, 'group_id', None)
 
         worker = WorkerFactory.default().create()
         return worker.delay(group_id, queue, func, args, kwargs, max_retries, pickle, delay, execute_inline)
@@ -42,15 +41,16 @@ def func_retry_decorator(worker_task):
 
 
 class task(object):
-    def __init__(self, queue_name=None, max_retries=None, use_pickle=None):
+    def __init__(self, queue_name=None, group_id=None, max_retries=None, use_pickle=None):
         # type: (str, int, bool) -> None
         self.queue_name = queue_name
         self.max_retries = max_retries
         self.use_pickle = use_pickle
+        self.group_id = group_id
 
     def __call__(self, *args, **kwargs):
         # type: (tuple, dict) -> Any
         func = args[0]
         func.retry_num = 0
-        func.delay = func_delay_decorator(func, self.queue_name, self.max_retries, self.use_pickle)
+        func.delay = func_delay_decorator(func, self.queue_name, self.group_id, self.max_retries, self.use_pickle)
         return func

--- a/eb_sqs/tests/worker/tests_worker_task.py
+++ b/eb_sqs/tests/worker/tests_worker_task.py
@@ -22,7 +22,7 @@ class WorkerTaskTest(TestCase):
         self.dummy_msg = '{"queue": "default", "retryId": "retry-uuid", "retry": 0, "func": "eb_sqs.tests.worker.tests_worker_task.dummy_function", "kwargs": {}, "maxRetries": 5, "args": [], "pickle": false, "id": "id-1", "groupId": "group-5"}'
 
     def test_serialize_worker_task(self):
-        worker_task = WorkerTask('id-1', 'group-5', 'default', dummy_function, [], {}, 5, 0, 'retry-uuid', False)
+        worker_task = WorkerTask('id-1', 'group-5', 'default', None, dummy_function, [], {}, 5, 0, 'retry-uuid', False)
         msg = worker_task.serialize()
 
         self.assertDictEqual(json.loads(msg), json.loads(self.dummy_msg))
@@ -41,7 +41,7 @@ class WorkerTaskTest(TestCase):
         self.assertEqual(worker_task.retry_id, 'retry-uuid')
 
     def test_serialize_pickle(self):
-        worker_task1 = WorkerTask('id-1', None, 'default', dummy_function, [], {'object': TestObject()}, 5, 0, None, True)
+        worker_task1 = WorkerTask('id-1', None, 'default', None, dummy_function, [], {'object': TestObject()}, 5, 0, None, True)
         msg = worker_task1.serialize()
 
         worker_task2 = WorkerTask.deserialize(msg)

--- a/eb_sqs/worker/queue_client.py
+++ b/eb_sqs/worker/queue_client.py
@@ -23,6 +23,6 @@ class QueueClient(object):
         self._group_id = group_id
 
     @abstractmethod
-    def add_message(self, queue_name, group_id, msg, delay):
+    def add_message(self, queue_name, fifo_group, msg, delay):
         # type: (unicode, unicode, int) -> None
         pass

--- a/eb_sqs/worker/queue_client.py
+++ b/eb_sqs/worker/queue_client.py
@@ -23,6 +23,6 @@ class QueueClient(object):
         self._group_id = group_id
 
     @abstractmethod
-    def add_message(self, queue_name, msg, delay):
+    def add_message(self, queue_name, group_id, msg, delay):
         # type: (unicode, unicode, int) -> None
         pass

--- a/eb_sqs/worker/worker.py
+++ b/eb_sqs/worker/worker.py
@@ -114,7 +114,7 @@ class Worker(object):
             if execute_inline:
                 return self._execute_task(worker_task)
             else:
-                self.queue_client.add_message(worker_task.queue, worker_task.serialize(), delay)
+                self.queue_client.add_message(worker_task.queue, worker_task.group_id, worker_task.serialize(), delay)
                 return None
         except QueueDoesNotExistException as ex:
             self._remove_from_group(worker_task)

--- a/eb_sqs/worker/worker.py
+++ b/eb_sqs/worker/worker.py
@@ -80,9 +80,9 @@ class Worker(object):
 
             raise ExecutionFailedException(worker_task.abs_func_name, ex)
 
-    def delay(self, group_id, queue_name, func, args, kwargs, max_retries, use_pickle, delay, execute_inline):
+    def delay(self, group_id, queue_name, fifo_group, func, args, kwargs, max_retries, use_pickle, delay, execute_inline):
         # type: (unicode, unicode, Any, tuple, dict, int, bool, int, bool) -> Any
-        worker_task = WorkerTask(str(uuid.uuid4()), group_id, queue_name, func, args, kwargs, max_retries, 0, None, use_pickle)
+        worker_task = WorkerTask(str(uuid.uuid4()), group_id, queue_name, fifo_group, func, args, kwargs, max_retries, 0, None, use_pickle)
         return self._enqueue_task(worker_task, delay, execute_inline, False, True)
 
     def retry(self, worker_task, delay, execute_inline, count_retries):
@@ -114,7 +114,7 @@ class Worker(object):
             if execute_inline:
                 return self._execute_task(worker_task)
             else:
-                self.queue_client.add_message(worker_task.queue, worker_task.group_id, worker_task.serialize(), delay)
+                self.queue_client.add_message(worker_task.queue, worker_task.fifo_group, worker_task.serialize(), delay)
                 return None
         except QueueDoesNotExistException as ex:
             self._remove_from_group(worker_task)

--- a/eb_sqs/worker/worker_task.py
+++ b/eb_sqs/worker/worker_task.py
@@ -14,7 +14,7 @@ except Exception:
 
 
 class WorkerTask(object):
-    def __init__(self, id, group_id, queue, func, args, kwargs, max_retries, retry, retry_id, use_pickle):
+    def __init__(self, id, group_id, queue, fifo_group, func, args, kwargs, max_retries, retry, retry_id, use_pickle):
         # type: (str, unicode, unicode, Any, tuple, dict, int, int, unicode, bool) -> None
         super(WorkerTask, self).__init__()
         self.id = id
@@ -27,6 +27,7 @@ class WorkerTask(object):
         self.retry = retry
         self.retry_id = retry_id
         self.use_pickle = use_pickle
+        self.fifo_group = fifo_group
 
         self.abs_func_name = '{}.{}'.format(self.func.__module__, self.func.__name__)
 
@@ -66,6 +67,7 @@ class WorkerTask(object):
                 self.id,
                 self.group_id,
                 self.queue,
+                self.fifo_group,
                 self.func,
                 self.args,
                 self.kwargs,
@@ -97,6 +99,7 @@ class WorkerTask(object):
 
         use_pickle = task.get('pickle', False)
         queue = task.get('queue', settings.DEFAULT_QUEUE)
+        fifo_group = task.get('fifo_group', None)
 
         task_args = task.get('args', [])
         args = WorkerTask._unpickle_args(task_args) if use_pickle else task_args
@@ -107,7 +110,7 @@ class WorkerTask(object):
         retry = task.get('retry', 0)
         retry_id = task.get('retryId')
 
-        return WorkerTask(id, group_id, queue, func, args, kwargs, max_retries, retry, retry_id, use_pickle)
+        return WorkerTask(id, group_id, queue, fifo_group, func, args, kwargs, max_retries, retry, retry_id, use_pickle)
 
     @staticmethod
     def _unpickle_args(args):


### PR DESCRIPTION
This adds fifo queue support to the version that the modern fertility project was using.  The latest version of the upstream project doesn't seem to work with modern fertility.


To use a fifo queue for a task, annotate the task like this:
```
@task(queue_name=FIFO_QUEUE_NAME, fifo_group='test-group')
def some_async_function()
```
The queue_name for fifo queues must end in `.fifo`, and the `fifo_group` controls concurrency - tasks with different groups can be executed independently, tasks in the same group are processed in order.

** no need to merge - the modern fertility project is fetching this dependency at this branch.